### PR TITLE
Trim whitespace from data usage metrics

### DIFF
--- a/HomeHub5/HomeHub5.php
+++ b/HomeHub5/HomeHub5.php
@@ -223,14 +223,14 @@ class HomeHub5 extends Utils {
 				$received_mb = 0;
 				
 				// Sent
-				$sent_explode = explode(' ', $e[0]);
+				$sent_explode = explode(' ', ltrim($e[0]));
 				$sent_mb = $sent_explode[0];
 				if ($sent_explode[1] == 'GB') {
 					$sent_mb = $sent_explode[0] * 1000;
 				}
 				
 				// Received
-				$received_explode = explode(' ', $e[1]);
+				$received_explode = explode(' ', ltrim($e[1]));
 				$received_mb = $received_explode[0];
 				if ($received_explode[1] == 'GB') {
 					$received_mb = $received_explode[0] * 1000;


### PR DESCRIPTION
When the data usage metrics are smaller numbers, the page
may contain whitespace to the left of the number. This
patch simply trims the whitespace from the left of the
number before exploding it so that the returned data is
more accurate.